### PR TITLE
Add a tool to test the compiled site locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,12 @@ yarn start
 yarn run build
 ```
 
+## Testing the web site
+```
+yarn run serve-static
+```
+
+Test the website at http://localhost:3002/
+
 ## Deployment
 When a commit is added to `master` branch, it will be deployed to GitHub Pages by the CI.

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   },
   "scripts": {
     "start": "env NEXT_DEV=1 next",
+    "serve-static": "node static-server.js",
     "build": "next build && next export",
     "postbuild": "cp -Rv public/* public/.nojekyll out",
     "deploy": "gh-pages --src '{.nojekyll,**/*}' -d out -m \"Deploy $(git rev-parse HEAD) to GitHub pages [ci skip]\"",
     "lint": "eslint *.js components pages",
     "heroku-postbuild": "env NEXT_DEV=1 yarn run build",
-    "heroku-start": "cd out && serve -p $PORT"
+    "heroku-start": "yarn run serve-static"
   },
   "devDependencies": {
     "babel-plugin-inline-react-svg": "^0.4.0",
@@ -34,6 +35,7 @@
     "webpack-dev-server": "^2.4.2"
   },
   "dependencies": {
+    "express": "^4.15.3",
     "next": "beta",
     "normalize.css": "^6.0.0",
     "react": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-standard": "^3.0.1",
     "gh-pages": "^1.0.0",
-    "serve": "^5.1.5",
     "webpack": "^2.3.3",
     "webpack-dev-server": "^2.4.2"
   },

--- a/static-server.js
+++ b/static-server.js
@@ -1,0 +1,18 @@
+const express = require('express')
+const app = express()
+const port = +process.env.PORT || 3002
+const outDir = require('path').join(__dirname, 'out')
+if (!require('fs').existsSync(outDir)) {
+  console.error('Error: "out" folder not found.')
+  console.error('Please run "yarn run build" before running this script.')
+  console.error()
+  process.exit(1)
+}
+app.use(require('compression')())
+app.use('/2.0.0', express.static(outDir))
+app.get('/', function (req, res) {
+  res.redirect('/2.0.0/')
+})
+app.listen(port, function () {
+  console.log('Now listening on port: ' + this.address().port)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,6 +1447,12 @@ debug@2.6.4, debug@^2.6.0:
   dependencies:
     ms "0.7.3"
 
+debug@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1967,6 +1973,39 @@ express@^4.13.3:
     utils-merge "1.0.0"
     vary "~1.1.0"
 
+express@^4.15.3:
+  version "4.15.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
+  dependencies:
+    accepts "~1.3.3"
+    array-flatten "1.1.1"
+    content-disposition "0.5.2"
+    content-type "~1.0.2"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.7"
+    depd "~1.1.0"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.0"
+    finalhandler "~1.0.3"
+    fresh "0.5.0"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.1"
+    path-to-regexp "0.1.7"
+    proxy-addr "~1.1.4"
+    qs "6.4.0"
+    range-parser "~1.2.0"
+    send "0.15.3"
+    serve-static "1.12.3"
+    setprototypeof "1.0.3"
+    statuses "~1.3.1"
+    type-is "~1.6.15"
+    utils-merge "1.0.0"
+    vary "~1.1.1"
+
 extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
@@ -2046,6 +2085,18 @@ finalhandler@~1.0.0:
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.1.tgz#bcd15d1689c0e5ed729b6f7f541a6df984117db8"
   dependencies:
     debug "2.6.3"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.1"
+    statuses "~1.3.1"
+    unpipe "~1.0.0"
+
+finalhandler@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
+  dependencies:
+    debug "2.6.7"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
@@ -3151,6 +3202,10 @@ ms@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-1.0.0.tgz#59adcd22edc543f7b5381862d31387b1f4bc9473"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -3696,7 +3751,7 @@ prop-types@15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-proxy-addr@~1.1.3:
+proxy-addr@~1.1.3, proxy-addr@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
   dependencies:
@@ -4122,6 +4177,24 @@ send@0.15.2:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+send@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.15.3.tgz#5013f9f99023df50d1bd9892c19e3defd1d53309"
+  dependencies:
+    debug "2.6.7"
+    depd "~1.1.0"
+    destroy "~1.0.4"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.0"
+    fresh "0.5.0"
+    http-errors "~1.6.1"
+    mime "1.3.4"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.3.1"
+
 serve-index@^1.7.2:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.8.0.tgz#7c5d96c13fb131101f93c1c5774f8516a1e78d3b"
@@ -4142,6 +4215,15 @@ serve-static@1.12.1:
     escape-html "~1.0.3"
     parseurl "~1.3.1"
     send "0.15.1"
+
+serve-static@1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.3.tgz#9f4ba19e2f3030c547f8af99107838ec38d5b1e2"
+  dependencies:
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    parseurl "~1.3.1"
+    send "0.15.3"
 
 serve@^5.1.5:
   version "5.1.5"
@@ -4577,7 +4659,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.14:
+type-is@~1.6.14, type-is@~1.6.15:
   version "1.6.15"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
   dependencies:
@@ -4706,7 +4788,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vary@~1.1.0:
+vary@~1.1.0, vary@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 


### PR DESCRIPTION
เวลารันในโหมด Development ที่อยู่ของไฟล์จะแตกต่างจากตอนเอาขึ้นเว็บ

| Mode | Root |
| --- | --- |
| development | / |
| production | /2.0.0/ |

ทำให้หากตั้ง Path reference ไม่ถูกต้อง จะทำให้หน้าเว็บใช้งานได้ตอน Develop แต่พอเอาขึ้นเว็บจริงแล้วใช้ไม่ได้ จึงทำสคริปต์เอาไว้ให้รันเซิฟเวอร์เพื่อทดสอบว่าพอเอาไปใช้จริงแล้วจะเวิร์คไหม

วิธีการใช้:

```
yarn run build
yarn run serve-static
```

แล้วเข้า http://localhost:3002/