### PR TITLE
Closed#103

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,5 @@ parser: babel-eslint
 rules:
   object-curly-spacing: [ error, always ]
   react/prop-types: off
-  jsx-a11y/rule-name: 2
 globals:
   React: false

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,6 @@ parser: babel-eslint
 rules:
   object-curly-spacing: [ error, always ]
   react/prop-types: off
-  jsx-a11y/rule-name": 2
+  jsx-a11y/rule-name: 2
 globals:
   React: false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,13 @@
+plugins:
+  - jsx-a11y
 extends:
   - standard
   - standard-react
+  - plugin:jsx-a11y/recommended
 parser: babel-eslint
 rules:
   object-curly-spacing: [ error, always ]
   react/prop-types: off
+  jsx-a11y/rule-name": 2
 globals:
   React: false

--- a/components/MainLayout.js
+++ b/components/MainLayout.js
@@ -37,7 +37,7 @@ const handleLinkClick = (event) => {
 
 export default function MainLayout ({ children }) {
   return (
-    <div onClick={handleLinkClick}>
+    <div onClick={handleLinkClick} onKeyDown={this.handleKeyDown} role='link' tabIndex='0' >
       <Head>
         <title>React Bangkok 2.0.0</title>
         <meta

--- a/components/SpeakersSection.js
+++ b/components/SpeakersSection.js
@@ -79,7 +79,7 @@ export default function TicketsSection () {
 function Speaker ({ name, title, photo, description }) {
   return (
     <div className='speaker-info'>
-      <img alt='Photo' src={photo} />
+      <img aria-hidden alt='Photo' src={photo} />
       <h3>{name}</h3>
       <p>{title}</p>
       <p className='description'>"{description}"</p>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-config-standard": "^10.2.0",
     "eslint-config-standard-react": "^4.3.0",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-standard": "^3.0.1",
     "gh-pages": "^1.0.0",
+    "global": "^4.3.2",
     "sw-precache": "^5.1.1",
     "webpack": "^2.3.3",
     "webpack-dev-server": "^2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,6 +110,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.5.0.tgz#85e3152cd8cc5bab18dbed61cd9c4fce54fa79c3"
+  dependencies:
+    ast-types-flow "0.0.7"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -131,6 +137,13 @@ array-find-index@^1.0.1:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -187,6 +200,10 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -212,6 +229,12 @@ aws-sign2@~0.6.0:
 aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+axobject-query@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
+  dependencies:
+    ast-types-flow "0.0.7"
 
 babel-code-frame@^6.16.0, babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -1364,6 +1387,10 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
+damerau-levenshtein@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1529,6 +1556,10 @@ elliptic@^6.0.0:
 emitter-mixin@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/emitter-mixin/-/emitter-mixin-0.0.3.tgz#5948cb286f2e48edc3b251a7cfc1f7883396d65c"
+
+emoji-regex@^6.1.0:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.2.tgz#a30b6fee353d406d96cfb9fa765bdc82897eff6e"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -1710,6 +1741,18 @@ eslint-plugin-import@^2.2.0:
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
     pkg-up "^1.0.0"
+
+eslint-plugin-jsx-a11y@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.0.3.tgz#4a939f76ec125010528823331bf948cc573380b6"
+  dependencies:
+    aria-query "^0.5.0"
+    array-includes "^3.0.3"
+    ast-types-flow "0.0.7"
+    axobject-query "^0.1.0"
+    damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^1.4.0"
 
 eslint-plugin-node@^4.2.2:
   version "4.2.2"
@@ -2779,7 +2822,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jsx-ast-utils@^1.3.4:
+jsx-ast-utils@^1.3.4, jsx-ast-utils@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
@@ -3666,6 +3709,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-countdown-now@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-countdown-now/-/react-countdown-now-1.2.0.tgz#9875c6634330e6c400fc829798358cbfa9aac77f"
 
 react-deep-force-update@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,7 +2242,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global@^4.3.0:
+global@^4.3.0, global@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   dependencies:


### PR DESCRIPTION
I've removed a specific rule and extended recommended configuration.

When I tested with 'yarn run lint', I found error from jsx-a11y validation in the image attached, so I fixed error refer from 
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md

Please let me know when they passed.

![18643653_10155863129621754_695370822_n](https://cloud.githubusercontent.com/assets/4596685/26298777/b92afd6c-3f02-11e7-8ff4-2a4d08e4abce.png)

